### PR TITLE
Pin GitHub Actions to commit SHAs with version comments

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -6,6 +6,6 @@ jobs:
     name: EditorConfig lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: editorconfig-checker/action-editorconfig-checker@v2
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: editorconfig-checker/action-editorconfig-checker@4b6cd6190d435e7e084fb35e36a096e98506f7b9 # v2.1.0
       name: Testing using editorconfig-checker

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -6,8 +6,8 @@ jobs:
     name: Markdownlint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: nosborn/github-action-markdown-cli@v3.5.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: nosborn/github-action-markdown-cli@9bfd0452ce630f6469986587db7f0feab5b22273 # v3.5.0
       name: Markdownlint
       with:
         files: .

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: ludeeus/action-shellcheck@2.0.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
       name: Shellcheck

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,7 +6,7 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.58.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: rojopolis/spellcheck-github-actions@0bf4b2f91efa259b52c202b09b0c3845c524ff36 # v0.58.0
       name: Spellcheck
 


### PR DESCRIPTION
This PR pins all GitHub Actions used in workflows to their latest release commit SHAs with human-readable version comments for improved security.

## Changes

- **actions/checkout**: Pinned to v6.0.1 (was using `@master`)
- **editorconfig-checker/action-editorconfig-checker**: Pinned to v2.1.0 (was using `@v2`)
- **nosborn/github-action-markdown-cli**: Pinned to v3.5.0 commit SHA (was using tag)
- **ludeeus/action-shellcheck**: Pinned to v2.0.0 commit SHA (was using tag)
- **rojopolis/spellcheck-github-actions**: Pinned to v0.58.0 commit SHA (was using tag)

## Benefits

- **Security**: Pinning to commit SHAs prevents malicious updates to tags
- **Dependabot compatible**: Version comments allow Dependabot to manage updates
- **Transparency**: Clear version numbers make it easy to see what's being used

All actions are now using the latest available releases as of January 2026.